### PR TITLE
Correct Google CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
 	<title>Story Cards</title>
 	<link rel="stylesheet" href="assets/jquery.ui.css" type="text/css" media="all" />
 	<link rel="stylesheet" href="assets/cards.app.css" type="text/css" media="all" />
-	 <script src='https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'></script>
-	 <script src='https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.21/jquery-ui.min.js'></script>
+	 <script src='http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'></script>
+	 <script src='http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.21/jquery-ui.min.js'></script>
 	 <script src='assets/js/jquery.flip.min.js'></script>
 	 <script src='assets/js/template.js'></script>
 	 <script src='assets/js/cards.app.js'></script>


### PR DESCRIPTION
Just installing this fails because Google does not serve JS libraries over HTTPS. This removes this.

Thanks.
